### PR TITLE
Clone filtered identities before bulk add

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -92,7 +92,8 @@ export default {
     },
     addAllFromFilter(filteredIdentities) {
       if (!this.isSessionActive) {
-        filteredIdentities.forEach(identity => {
+        const toAdd = [...filteredIdentities];
+        toAdd.forEach(identity => {
           const index = this.identities.findIndex(
             (aI) => aI.firstName === identity.firstName && aI.lastName === identity.lastName
           );


### PR DESCRIPTION
## Summary
- clone the filtered identities list before iterating in `addAllFromFilter`
- iterate over the snapshot while splicing and pushing to move every filtered identity

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68dd98161cc8832894511fdb6554828d