### PR TITLE
Use identity IDs for active identity management

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -81,7 +81,7 @@ export default {
     addIdentityToActive(identity) {
       if (!this.isSessionActive) {
         const index = this.identities.findIndex(
-          (aI) => aI.firstName === identity.firstName && aI.lastName === identity.lastName
+          (aI) => aI.id === identity.id
         );
         if (index !== -1) {
           this.activeIdentities.push(this.identities.splice(index, 1)[0]);
@@ -91,7 +91,7 @@ export default {
     removeIdentityFromActive(identity) {
       if (!this.isSessionActive) {
         const index = this.activeIdentities.findIndex(
-          (aI) => aI.firstName === identity.firstName && aI.lastName === identity.lastName
+          (aI) => aI.id === identity.id
         );
         if (index !== -1) {
           this.identities.push(this.activeIdentities.splice(index, 1)[0]);
@@ -103,7 +103,7 @@ export default {
         const toAdd = [...filteredIdentities];
         toAdd.forEach(identity => {
           const index = this.identities.findIndex(
-            (aI) => aI.firstName === identity.firstName && aI.lastName === identity.lastName
+            (aI) => aI.id === identity.id
           );
           if (index !== -1) {
             this.activeIdentities.push(this.identities.splice(index, 1)[0]);


### PR DESCRIPTION
## Summary
- use `identity.id` for lookups when adding or removing active identities to avoid duplicate name collisions
- continue to move the spliced identity object during push/splice operations

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68dd9cf8a99c8328a7048d2ba9ed24b1