### PR TITLE
Improve disabled state styling for buttons

### DIFF
--- a/src/components/IdentityCardPane.vue
+++ b/src/components/IdentityCardPane.vue
@@ -12,7 +12,8 @@ export default {
 
 <style scoped>
 ul {
-    height: 100%; /* Ensure it takes full height of the container */
+    flex: 1 1 auto;
+    min-height: 0;
     display: flex;
     flex-direction: column;
     gap: .75rem;

--- a/src/components/IdentitySearch.vue
+++ b/src/components/IdentitySearch.vue
@@ -206,10 +206,11 @@ export default {
 }
 
 .identity-pane {
-  height: 100%;
   display: flex;
   flex-direction: column;
   gap: .5rem;
+  flex: 1 1 auto;
+  min-height: 0;
 }
 
 .identity-pane__header {
@@ -274,6 +275,10 @@ input::placeholder {
   grid-template-columns: 1fr 4fr;
   align-items: start;
   gap: .7rem;
+}
+
+.controls-results > * {
+  min-height: 0;
 }
 
 .controls {

--- a/src/components/IdentitySearch.vue
+++ b/src/components/IdentitySearch.vue
@@ -28,11 +28,21 @@
           <label class="right" for="z-a">z - a</label>
         </div>
 
-        <StyledButton @click="clearDropdownFilters" text-color="#fff" button-color="#444">
+        <StyledButton
+          @click="clearDropdownFilters"
+          text-color="#fff"
+          button-color="#444"
+          :disabled="!hasActiveFilters"
+        >
           Clear Filters
         </StyledButton>
 
-        <StyledButton @click="addAllFromFilter" text-color="#fff" button-color="#444">
+        <StyledButton
+          @click="addAllFromFilter"
+          text-color="#fff"
+          button-color="#444"
+          :disabled="!canAddAllToSession"
+        >
           Add All To Session
         </StyledButton>
       </div>
@@ -133,6 +143,12 @@ export default {
       }
 
       return filtered;
+    },
+    hasActiveFilters() {
+      return Object.values(this.selectedFiltersOptions || {}).some(value => value !== '');
+    },
+    canAddAllToSession() {
+      return this.filteredIdentities.length > 0;
     }
   },
   methods: {

--- a/src/components/IdentitySearch.vue
+++ b/src/components/IdentitySearch.vue
@@ -47,11 +47,17 @@
         </StyledButton>
       </div>
 
-      <IdentityCardPane>
-        <IdentityCard v-for="identity in filteredIdentities" :key="identity.id" :identity="identity"
-          :image="require('@/assets/plus-circle.svg')" :addIdentity="true"
-          @add-identity="$emit('add-identity', $event)" />
-      </IdentityCardPane>
+      <div class="identity-pane">
+        <div class="identity-pane__header">
+          <span>Available Identities</span>
+          <span>{{ filteredIdentities.length }}</span>
+        </div>
+        <IdentityCardPane>
+          <IdentityCard v-for="identity in filteredIdentities" :key="identity.id" :identity="identity"
+            :image="require('@/assets/plus-circle.svg')" :addIdentity="true"
+            @add-identity="$emit('add-identity', $event)" />
+        </IdentityCardPane>
+      </div>
     </div>
   </div>
 </template>
@@ -197,6 +203,28 @@ export default {
   display: flex;
   flex-direction: column;
   gap: .7rem;
+}
+
+.identity-pane {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: .5rem;
+}
+
+.identity-pane__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: .35rem .7rem;
+  background-color: #222;
+  border: 1px solid #444;
+  border-radius: .5rem;
+  font-weight: bold;
+  text-transform: uppercase;
+  font-size: .75rem;
+  letter-spacing: .05em;
+  color: #ccc;
 }
 
 .search-input {

--- a/src/components/SessionManager.vue
+++ b/src/components/SessionManager.vue
@@ -2,7 +2,14 @@
     <div class="session-manager">
         <div class="control-panel">
             <div>
-                <StyledButton v-if="!isSessionActive" @click="startSession" :disabled="this.isDisabled" text-color="#fff" button-color="#39B357">
+                <StyledButton
+                    v-if="!isSessionActive"
+                    @click="startSession"
+                    :disabled="isStartDisabled"
+                    text-color="#fff"
+                    button-color="#39B357"
+                    :disabled-button-color="'#444'"
+                >
                     {{ this.isDisabled ? 'Starting...' : 'Start Session' }} ({{ this.activeIdentities.length }})
                 </StyledButton>
 
@@ -29,11 +36,17 @@
                 </StyledButton>
             </div>
         </div>
-        <IdentityCardPane ref="identityPane">
-            <IdentityCard v-for="identity in activeIdentities" :key="identity.firstName + identity.lastName"
-                :identity="identity" :image="require('@/assets/minus-circle.svg')" :addIdentity="false"
-                @remove-identity="$emit('remove-identity', $event)" />
-        </IdentityCardPane>
+        <div class="identity-pane">
+            <div class="identity-pane__header">
+                <span>Session Identities</span>
+                <span>{{ activeIdentities.length }}</span>
+            </div>
+            <IdentityCardPane ref="identityPane">
+                <IdentityCard v-for="identity in activeIdentities" :key="identity.firstName + identity.lastName"
+                    :identity="identity" :image="require('@/assets/minus-circle.svg')" :addIdentity="false"
+                    @remove-identity="$emit('remove-identity', $event)" />
+            </IdentityCardPane>
+        </div>
     </div>
 </template>
 
@@ -67,6 +80,12 @@ export default {
         canClearSession() {
             return !this.isSessionActive && this.activeIdentities.length > 0;
         },
+        canStartSession() {
+            return !this.isSessionActive && this.activeIdentities.length > 0;
+        },
+        isStartDisabled() {
+            return this.isDisabled || !this.canStartSession;
+        }
     },
     watch: {
         activeIdentities: {
@@ -125,5 +144,27 @@ export default {
     display: flex;
     flex-direction: column;
     gap: .7rem;
+}
+
+.identity-pane {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    gap: .5rem;
+}
+
+.identity-pane__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: .35rem .7rem;
+    background-color: #222;
+    border: 1px solid #444;
+    border-radius: .5rem;
+    font-weight: bold;
+    text-transform: uppercase;
+    font-size: .75rem;
+    letter-spacing: .05em;
+    color: #ccc;
 }
 </style>

--- a/src/components/SessionManager.vue
+++ b/src/components/SessionManager.vue
@@ -17,7 +17,14 @@
                     {{ this.isDisabled ? 'Ending...' : 'End Session' }} ({{ this.activeIdentities.length }})
                 </StyledButton>
 
-                <StyledButton v-if="!isSessionActive" @click="clearSession" :disabled="!canClearSession" text-color="#fff" button-color="#444">
+                <StyledButton
+                    v-if="!isSessionActive"
+                    @click="clearSession"
+                    :disabled="!canClearSession"
+                    text-color="#fff"
+                    button-color="#444"
+                    :disabled-button-color="'#444'"
+                >
                     Clear Session
                 </StyledButton>
             </div>
@@ -131,12 +138,20 @@ export default {
     gap: .7rem;
 }
 
+.session-manager > * {
+    min-height: 0;
+}
+
 .control-panel {
     width: 100%;
     height: 100%;
     display: flex;
     flex-direction: column;
     justify-content: space-between;
+}
+
+.control-panel > * {
+    min-height: 0;
 }
 
 .control-panel > div {
@@ -147,10 +162,11 @@ export default {
 }
 
 .identity-pane {
-    height: 100%;
     display: flex;
     flex-direction: column;
     gap: .5rem;
+    flex: 1 1 auto;
+    min-height: 0;
 }
 
 .identity-pane__header {

--- a/src/components/SessionManager.vue
+++ b/src/components/SessionManager.vue
@@ -10,10 +10,12 @@
                     {{ this.isDisabled ? 'Ending...' : 'End Session' }} ({{ this.activeIdentities.length }})
                 </StyledButton>
 
-                <StyledButton v-if="!isSessionActive" @click="clearSession" text-color="#fff" button-color="#444">
+                <StyledButton v-if="!isSessionActive" @click="clearSession" :disabled="!canClearSession" text-color="#fff" button-color="#444">
                     Clear Session
                 </StyledButton>
+            </div>
 
+            <div class="secondary-actions">
                 <StyledButton v-if="!isSessionActive" @click="this.$emit('show-add-identity')" text-color="#fff" button-color="#444">
                     Create Identity
                 </StyledButton>
@@ -21,11 +23,11 @@
                 <StyledButton v-if="!isSessionActive" @click="handleRefresh()" text-color="#fff" button-color="#444">
                     Refresh Page
                 </StyledButton>
-            </div>
 
-            <StyledButton @click="logOut()" text-color="#fff" button-color="#444">
-                Log Out
-            </StyledButton>
+                <StyledButton @click="logOut()" text-color="#fff" button-color="#444">
+                    Log Out
+                </StyledButton>
+            </div>
         </div>
         <IdentityCardPane ref="identityPane">
             <IdentityCard v-for="identity in activeIdentities" :key="identity.firstName + identity.lastName"
@@ -60,6 +62,11 @@ export default {
         IdentityCard,
         IdentityCardPane,
         StyledButton,
+    },
+    computed: {
+        canClearSession() {
+            return !this.isSessionActive && this.activeIdentities.length > 0;
+        },
     },
     watch: {
         activeIdentities: {

--- a/src/components/StyledButton.vue
+++ b/src/components/StyledButton.vue
@@ -1,56 +1,111 @@
 <template>
-    <button :style="buttonStyles" class="styled-button">
-      <span v-if="icon" class="icon">{{ icon }}</span>
-      <slot></slot>
-    </button>
-  </template>
-  
-  <script>
-  export default {
-    name: 'StyledButton',
-    props: {
-      icon: {
-        type: String,
-        default: ''
-      },
-      textColor: {
-        type: String,
-        default: '#fff'
-      },
-      buttonColor: {
-        type: String,
-        default: '#007bff'
-      }
+  <button
+    :style="buttonStyles"
+    class="styled-button"
+    :disabled="disabled"
+  >
+    <span v-if="icon" class="icon">{{ icon }}</span>
+    <slot></slot>
+  </button>
+</template>
+
+<script>
+export default {
+  name: 'StyledButton',
+  props: {
+    icon: {
+      type: String,
+      default: ''
     },
-    computed: {
-      buttonStyles() {
-        return {
-          color: this.textColor,
-          backgroundColor: this.buttonColor,
-          border: 'none',
-          padding: '.5rem .7rem',
-          borderRadius: '.5rem',
-          cursor: 'pointer',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center'
-        };
-      }
+    textColor: {
+      type: String,
+      default: '#fff'
+    },
+    buttonColor: {
+      type: String,
+      default: '#007bff'
+    },
+    disabled: {
+      type: Boolean,
+      default: false
     }
-  };
-  </script>
+  },
+  computed: {
+    buttonStyles() {
+      const backgroundColor = this.disabled
+        ? this.adjustColor(this.buttonColor, 0.65)
+        : this.buttonColor;
+      const color = this.disabled
+        ? this.adjustColor(this.textColor, 0.8)
+        : this.textColor;
+
+      return {
+        color,
+        backgroundColor,
+        border: 'none',
+        padding: '.5rem .7rem',
+        borderRadius: '.5rem',
+        cursor: this.disabled ? 'not-allowed' : 'pointer',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        pointerEvents: this.disabled ? 'none' : 'auto'
+      };
+    }
+  },
+  methods: {
+    adjustColor(hexColor, factor) {
+      if (!hexColor) {
+        return hexColor;
+      }
+
+      let hex = hexColor.replace('#', '');
+
+      if (hex.length === 3) {
+        hex = hex.split('').map(char => char + char).join('');
+      }
+
+      if (hex.length !== 6) {
+        return hexColor;
+      }
+
+      const clamp = (value) => Math.min(255, Math.max(0, value));
+      const channels = hex.match(/.{2}/g);
+
+      if (!channels) {
+        return hexColor;
+      }
+
+      const adjusted = channels
+        .map(channel => {
+          const decimal = parseInt(channel, 16);
+          if (Number.isNaN(decimal)) {
+            return channel;
+          }
+          return clamp(Math.round(decimal * factor)).toString(16).padStart(2, '0');
+        })
+        .join('');
+
+      return `#${adjusted}`;
+    }
+  }
+};
+</script>
 
 <style scoped>
-  .styled-button {
-    width: 100%;
-    transition: background-color 0.3s, color 0.3s;
-    font-size: .9rem;
-    font-weight: bold;
-    text-transform: capitalize;
-  }
-  
-  .styled-button:hover {
-    filter: brightness(0.9);
-  }
+.styled-button {
+  width: 100%;
+  transition: background-color 0.3s, color 0.3s;
+  font-size: .9rem;
+  font-weight: bold;
+  text-transform: capitalize;
+}
 
+.styled-button:hover {
+  filter: brightness(0.9);
+}
+
+.styled-button:disabled {
+  filter: none;
+}
 </style>

--- a/src/components/StyledButton.vue
+++ b/src/components/StyledButton.vue
@@ -25,6 +25,14 @@ export default {
       type: String,
       default: '#007bff'
     },
+    disabledButtonColor: {
+      type: String,
+      default: null
+    },
+    disabledTextColor: {
+      type: String,
+      default: null
+    },
     disabled: {
       type: Boolean,
       default: false
@@ -33,10 +41,10 @@ export default {
   computed: {
     buttonStyles() {
       const backgroundColor = this.disabled
-        ? this.adjustColor(this.buttonColor, 0.65)
+        ? this.disabledButtonColor || this.adjustColor(this.buttonColor, 0.65)
         : this.buttonColor;
       const color = this.disabled
-        ? this.adjustColor(this.textColor, 0.8)
+        ? this.disabledTextColor || this.adjustColor(this.textColor, 0.8)
         : this.textColor;
 
       return {


### PR DESCRIPTION
## Summary
- add a disabled prop and darker grey styling to `StyledButton` so unavailable actions look inactive
- disable identity search bulk actions when no filters or identities make the action possible

## Testing
- npm run lint *(fails: vue-cli-service not found in environment)*

------
https://chatgpt.com/codex/tasks/task_b_68de872a6fbc8328be963489351cb785