### PR TITLE
feat: restyle capture link with animated gradients

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -5,16 +5,76 @@
     @identity-created="handleIdentityCreated" @hide-add-identity="this.showAddIdentity = false"
     @session-expired="handleSessionExpired" />
 
-  <div class="top-section">
-    <identity-search :identities="identities" :filterObject="identitiesFilterObject"
-      :isSessionActive="this.isSessionActive" @add-identity="addIdentityToActive"
-      @add-all-from-filter="addAllFromFilter" />
-  </div>
+  <div class="app-shell">
+    <header class="hero">
+      <div class="hero__background">
+        <span class="hero__glow hero__glow--one"></span>
+        <span class="hero__glow hero__glow--two"></span>
+        <span class="hero__glow hero__glow--three"></span>
+      </div>
 
-  <div class="bottom-section">
-    <session-manager :activeIdentities="activeIdentities" :isSessionActive="this.isSessionActive" :isDisabled="this.isDisabled"
-      @start-session="startSession" @end-session="endSession" @remove-identity="removeIdentityFromActive"
-      @clear-identities="clearIdentitiesFromActive" @show-add-identity="this.showAddIdentity = true" />
+      <div class="hero__content">
+        <p class="hero__eyebrow">CaptureLink Sessions</p>
+        <h1>Orchestrate identity capture with gradients of control</h1>
+        <p class="hero__description">
+          Search, filter, and activate identities in a single, immersive workspace inspired by the latest n8n
+          experience. Craft vibrant sessions with confidence and keep operations flowing in real time.
+        </p>
+
+        <div class="hero__actions">
+          <button class="hero__cta" type="button" @click="openCreateIdentity">Create identity</button>
+          <button class="hero__cta hero__cta--ghost" type="button" @click="refreshIdentities">
+            Refresh identities
+          </button>
+        </div>
+
+        <div class="hero__stats">
+          <div class="hero__stat">
+            <span class="hero__stat-value">{{ availableIdentitiesCount }}</span>
+            <span class="hero__stat-label">Available identities</span>
+          </div>
+          <div class="hero__stat">
+            <span class="hero__stat-value">{{ activeIdentityCount }}</span>
+            <span class="hero__stat-label">In session queue</span>
+          </div>
+          <div class="hero__stat">
+            <span class="hero__stat-value" :class="{ 'is-live': isSessionActive }">{{ sessionStatusText }}</span>
+            <span class="hero__stat-label">Session status</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="hero__visual">
+        <div class="hero__orb hero__orb--left"></div>
+        <div class="hero__orb hero__orb--right"></div>
+        <div class="hero__orb hero__orb--bottom"></div>
+      </div>
+    </header>
+
+    <main class="dashboard">
+      <section class="panel panel--identities">
+        <div class="panel__intro">
+          <h2>Identity library</h2>
+          <p>Discover and filter the right identities before activating a capture session.</p>
+        </div>
+
+        <identity-search :identities="identities" :filterObject="identitiesFilterObject"
+          :isSessionActive="this.isSessionActive" @add-identity="addIdentityToActive"
+          @add-all-from-filter="addAllFromFilter" />
+      </section>
+
+      <section class="panel panel--session">
+        <div class="panel__intro">
+          <h2>Session builder</h2>
+          <p>Stage identities, control the queue, and launch a capture link at the perfect moment.</p>
+        </div>
+
+        <session-manager :activeIdentities="activeIdentities" :isSessionActive="this.isSessionActive"
+          :isDisabled="this.isDisabled" @start-session="startSession" @end-session="endSession"
+          @remove-identity="removeIdentityFromActive" @clear-identities="clearIdentitiesFromActive"
+          @show-add-identity="this.showAddIdentity = true" />
+      </section>
+    </main>
   </div>
 </template>
 
@@ -56,6 +116,12 @@ export default {
     DialogAddIdentity
   },
   computed: {
+    availableIdentitiesCount() {
+      return this.identities.length;
+    },
+    activeIdentityCount() {
+      return this.activeIdentities.length;
+    },
     identitiesFilterObject() {
       const allKnownIdentities = [
         ...this.identities,
@@ -63,6 +129,9 @@ export default {
       ]
 
       return getObjectArrayFilterObject(allKnownIdentities)
+    },
+    sessionStatusText() {
+      return this.isSessionActive ? 'Live session' : 'Idle';
     }
   },
   methods: {
@@ -179,28 +248,308 @@ export default {
         this.identities = [...this.activeIdentities, ...this.identities]
         this.activeIdentities = []
       }
+    },
+    openCreateIdentity() {
+      if (!this.isSessionActive) {
+        this.showAddIdentity = true
+      }
+    },
+    refreshIdentities() {
+      this.loadIdentities()
     }
   },
 };
 </script>
 
 <style>
+:root {
+  color-scheme: dark;
+  font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, 'Helvetica Neue', sans-serif;
+  background-color: #060b1a;
+}
+
+body {
+  background: radial-gradient(circle at top left, rgba(111, 82, 255, 0.35), transparent 40%),
+    radial-gradient(circle at 80% 0%, rgba(255, 122, 195, 0.35), transparent 45%),
+    #050712;
+  min-height: 100vh;
+  margin: 0;
+  color: #f4f5ff;
+}
+
 #app {
-  height: 100vh;
-  font-family: sans-serif;
+  min-height: 100vh;
   display: flex;
   flex-direction: column;
-  gap: 1%;
-  padding: 0.7rem;
+  padding: 2.5rem clamp(1.5rem, 4vw, 3.5rem) 3rem;
+  box-sizing: border-box;
 }
 
-.top-section {
-  height: 54.5%;
-  flex: 0 0 auto;
+.app-shell {
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
 }
 
-.bottom-section {
-  height: 44.5%;
-  flex: 0 0 auto;
+.hero {
+  position: relative;
+  overflow: hidden;
+  border-radius: 2.25rem;
+  padding: clamp(2.5rem, 5vw, 4rem);
+  background: radial-gradient(circle at 20% 20%, rgba(255, 145, 234, 0.45) 0%, transparent 60%),
+    linear-gradient(135deg, rgba(17, 27, 54, 0.95) 10%, rgba(33, 18, 78, 0.92) 90%);
+  box-shadow: 0 25px 80px rgba(16, 18, 52, 0.55);
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: clamp(2rem, 5vw, 4rem);
+  isolation: isolate;
+}
+
+.hero__background {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  overflow: hidden;
+  z-index: 0;
+}
+
+.hero__glow {
+  position: absolute;
+  width: clamp(18rem, 40vw, 28rem);
+  height: clamp(18rem, 40vw, 28rem);
+  filter: blur(60px);
+  opacity: 0.65;
+  animation: drift 18s ease-in-out infinite alternate;
+}
+
+.hero__glow--one {
+  top: -25%;
+  left: -10%;
+  background: radial-gradient(circle, rgba(129, 88, 255, 0.85), transparent 65%);
+}
+
+.hero__glow--two {
+  top: 10%;
+  right: 5%;
+  background: radial-gradient(circle, rgba(255, 134, 194, 0.85), transparent 60%);
+  animation-duration: 22s;
+}
+
+.hero__glow--three {
+  bottom: -20%;
+  left: 40%;
+  background: radial-gradient(circle, rgba(94, 211, 255, 0.65), transparent 60%);
+  animation-duration: 26s;
+}
+
+@keyframes drift {
+  from {
+    transform: translate3d(-5%, -5%, 0) scale(1);
+  }
+  to {
+    transform: translate3d(5%, 5%, 0) scale(1.1);
+  }
+}
+
+.hero__content,
+.hero__visual {
+  position: relative;
+  z-index: 1;
+}
+
+.hero__content {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.hero__eyebrow {
+  font-size: 0.85rem;
+  letter-spacing: 0.25em;
+  text-transform: uppercase;
+  color: rgba(228, 232, 255, 0.75);
+}
+
+.hero__description {
+  max-width: 32rem;
+  color: rgba(235, 238, 255, 0.75);
+  line-height: 1.7;
+  font-size: 1.05rem;
+}
+
+.hero__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.85rem;
+}
+
+.hero__cta {
+  border: none;
+  border-radius: 999px;
+  padding: 0.85rem 1.65rem;
+  font-weight: 600;
+  font-size: 0.95rem;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  color: #091021;
+  background: linear-gradient(120deg, #ff9ad7 0%, #8a7dff 50%, #5f9dff 100%);
+  box-shadow: 0 18px 45px rgba(108, 99, 255, 0.45);
+  transition: transform 0.4s ease, box-shadow 0.4s ease;
+}
+
+.hero__cta:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 25px 60px rgba(108, 99, 255, 0.55);
+}
+
+.hero__cta:active {
+  transform: translateY(0);
+}
+
+.hero__cta--ghost {
+  background: rgba(8, 11, 27, 0.55);
+  border: 1px solid rgba(160, 173, 255, 0.5);
+  color: rgba(226, 230, 255, 0.9);
+  box-shadow: none;
+}
+
+.hero__cta--ghost:hover {
+  border-color: rgba(226, 230, 255, 0.8);
+  box-shadow: 0 18px 45px rgba(47, 55, 126, 0.35);
+}
+
+.hero__stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: clamp(1rem, 3vw, 2.5rem);
+}
+
+.hero__stat {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.hero__stat-value {
+  font-size: clamp(1.4rem, 3vw, 2rem);
+  font-weight: 600;
+  color: #f8f7ff;
+}
+
+.hero__stat-value.is-live {
+  color: #66f0c6;
+}
+
+.hero__stat-label {
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(218, 225, 255, 0.6);
+}
+
+.hero__visual {
+  display: grid;
+  place-items: center;
+  position: relative;
+  min-height: 18rem;
+}
+
+.hero__orb {
+  position: absolute;
+  width: clamp(8rem, 22vw, 16rem);
+  height: clamp(8rem, 22vw, 16rem);
+  border-radius: 50%;
+  filter: blur(0px);
+  opacity: 0.8;
+  animation: float 14s ease-in-out infinite;
+}
+
+.hero__orb--left {
+  background: radial-gradient(circle, rgba(255, 145, 234, 0.8), transparent 70%);
+  top: 10%;
+  left: 12%;
+}
+
+.hero__orb--right {
+  background: radial-gradient(circle, rgba(126, 155, 255, 0.9), transparent 70%);
+  top: -5%;
+  right: 10%;
+  animation-duration: 18s;
+}
+
+.hero__orb--bottom {
+  background: radial-gradient(circle, rgba(80, 223, 255, 0.75), transparent 70%);
+  bottom: -5%;
+  right: 25%;
+  animation-duration: 20s;
+}
+
+@keyframes float {
+  0% {
+    transform: translate3d(-10%, 5%, 0) scale(0.95);
+  }
+  50% {
+    transform: translate3d(5%, -5%, 0) scale(1.05);
+  }
+  100% {
+    transform: translate3d(-5%, 10%, 0) scale(0.97);
+  }
+}
+
+.dashboard {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+}
+
+.panel {
+  position: relative;
+  padding: clamp(1.5rem, 3vw, 2.5rem);
+  border-radius: 1.75rem;
+  background: linear-gradient(160deg, rgba(13, 19, 42, 0.85), rgba(10, 13, 30, 0.65));
+  border: 1px solid rgba(128, 140, 255, 0.25);
+  box-shadow: 0 30px 60px rgba(5, 8, 21, 0.45);
+  backdrop-filter: blur(24px);
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+}
+
+.panel::after {
+  content: '';
+  position: absolute;
+  inset: 1px;
+  border-radius: inherit;
+  pointer-events: none;
+  background: linear-gradient(140deg, rgba(146, 109, 255, 0.12), rgba(76, 205, 255, 0.08));
+  mix-blend-mode: screen;
+  opacity: 0.5;
+}
+
+.panel__intro {
+  position: relative;
+  z-index: 1;
+}
+
+.panel__intro h2 {
+  margin: 0 0 0.35rem;
+  font-size: 1.4rem;
+  color: #f5f7ff;
+}
+
+.panel__intro p {
+  margin: 0;
+  color: rgba(216, 223, 255, 0.7);
+  line-height: 1.6;
+}
+
+@media (max-width: 768px) {
+  #app {
+    padding: 1.5rem 1rem 2.5rem;
+  }
+
+  .hero {
+    border-radius: 1.75rem;
+  }
 }
 </style>

--- a/src/components/IdentitySearch.vue
+++ b/src/components/IdentitySearch.vue
@@ -43,11 +43,16 @@
           </div>
         </div>
 
-        <StyledButton @click="clearDropdownFilters" text-color="#222" button-color="#fff" :disabled="!hasActiveFilters">
+        <StyledButton @click="clearDropdownFilters" text-color="#0e1430" button-color="#f4f6ff"
+          :disabled="!hasActiveFilters">
           Clear Filters
         </StyledButton>
 
-        <StyledButton @click="addAllFromFilter" text-color="#222" button-color="#fff" :disabled="!canAddAllToSession">
+        <StyledButton @click="addAllFromFilter" text-color="#ffffff"
+          button-color="linear-gradient(135deg, #ff85d8 0%, #7a7dff 45%, #46d7ff 100%)"
+          :disabled-button-color="'rgba(38, 46, 84, 0.75)'"
+          :disabled-text-color="'rgba(189, 201, 255, 0.6)'"
+          :disabled="!canAddAllToSession">
           Add All To Session
         </StyledButton>
       </div>
@@ -216,12 +221,12 @@ export default {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 0 1rem .25rem 1rem;
-  font-weight: bold;
+  padding: 0 1rem .75rem 1rem;
+  font-weight: 600;
   text-transform: uppercase;
   font-size: .75rem;
-  letter-spacing: .05em;
-  color: #ccc;
+  letter-spacing: .08em;
+  color: rgba(218, 225, 255, 0.75);
 }
 
 .search-input {
@@ -242,15 +247,16 @@ export default {
 .search-input input {
   width: 100%;
   height: 100%;
-  border-radius: 0.5rem;
-  background-color: #222;
-  border: 1px solid #444;
-  color: #fff;
-  padding: .4rem;
+  border-radius: 0.85rem;
+  background-color: rgba(19, 26, 50, 0.85);
+  border: 1px solid rgba(126, 140, 255, 0.35);
+  color: #f6f7ff;
+  padding: .65rem .75rem;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
 }
 
 input::placeholder {
-  color: #ccc;
+  color: rgba(202, 211, 255, 0.55);
 }
 
 .search-input button {
@@ -259,20 +265,18 @@ input::placeholder {
   top: 50%;
   transform: translateY(-50%);
   border: none;
-  background: #2220;
-  /* border: 1px solid #444; */
-  color: #ccc;
-  padding: .4rem;
-  border-radius: .45rem;
+  background: rgba(255, 255, 255, 0.04);
+  color: rgba(214, 221, 255, 0.7);
+  padding: .35rem .55rem;
+  border-radius: .6rem;
   cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
-  /* font-weight: bold; */
 }
 
 .search-input button:hover {
-  background: #333;
+  background: rgba(120, 132, 255, 0.18);
 }
 
 .controls-results {
@@ -306,27 +310,29 @@ input::placeholder {
   display: flex;
   flex-direction: column;
   gap: .7rem;
-  background-color: #222;
-  border-radius: .5rem;
-  border: 1px solid #444;
-  padding: .7rem;
+  background: linear-gradient(160deg, rgba(13, 19, 42, 0.8), rgba(9, 12, 30, 0.65));
+  border-radius: 1rem;
+  border: 1px solid rgba(134, 150, 255, 0.25);
+  padding: .9rem;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+  backdrop-filter: blur(18px);
 }
 
 .filter-row label {
   display: block;
   margin-bottom: .4rem;
-  color: #ccc;
+  color: rgba(222, 229, 255, 0.75);
   text-transform: capitalize;
   font-size: small;
 }
 
 .filter-row select {
   width: 100%;
-  border-radius: .5rem;
-  background-color: #222;
-  border: 1px solid #444;
-  color: #ccc;
-  padding: .4rem;
+  border-radius: .75rem;
+  background-color: rgba(17, 22, 42, 0.8);
+  border: 1px solid rgba(94, 109, 188, 0.35);
+  color: #f2f4ff;
+  padding: .55rem;
 }
 
 .rocker-switch {
@@ -344,9 +350,10 @@ input::placeholder {
   width: 50%;
   text-align: center;
   font-size: .7rem;
-  padding: 0.3rem;
-  background-color: #222;
-  color: #ccc;
+  padding: 0.45rem;
+  background: rgba(18, 24, 50, 0.75);
+  border: 1px solid rgba(120, 136, 240, 0.3);
+  color: rgba(216, 223, 255, 0.8);
   cursor: pointer;
 }
 
@@ -363,6 +370,7 @@ input::placeholder {
 }
 
 .rocker-switch input[type="radio"]:checked+label {
-  background-color: #333;
+  background: linear-gradient(135deg, rgba(126, 155, 255, 0.85), rgba(65, 215, 255, 0.65));
+  color: #091021;
 }
 </style>

--- a/src/components/SessionManager.vue
+++ b/src/components/SessionManager.vue
@@ -12,32 +12,39 @@
             <div class="control-panel">
                 <div>
                     <StyledButton v-if="!isSessionActive" @click="startSession" :disabled="isStartDisabled"
-                        text-color="#222" button-color="#39B357" :disabled-button-color="'#222'">
+                        text-color="#081124"
+                        button-color="linear-gradient(135deg, #63ffc7 0%, #51d5ff 45%, #8e7aff 100%)"
+                        :disabled-button-color="'rgba(37, 49, 86, 0.8)'"
+                        :disabled-text-color="'rgba(176, 192, 255, 0.6)'">
                         {{ this.isDisabled ? 'Starting...' : 'Start Session' }}
                     </StyledButton>
 
-                    <StyledButton v-if="isSessionActive" @click="endSession" text-color="#222" button-color="#ff6644">
+                    <StyledButton v-if="isSessionActive" @click="endSession" text-color="#ffffff"
+                        button-color="linear-gradient(135deg, #ff8f84 0%, #ff64c6 48%, #815cff 100%)"
+                        :disabled-button-color="'rgba(58, 39, 68, 0.7)'"
+                        :disabled-text-color="'rgba(234, 210, 255, 0.6)'">
                         {{ this.isDisabled ? 'Ending...' : 'End Session' }}
                     </StyledButton>
 
                     <StyledButton v-if="!isSessionActive" @click="clearSession" :disabled="!canClearSession"
-                        text-color="#222" button-color="#fff">
+                        text-color="#0b1430" button-color="#f3f6ff">
                         Clear Session
                     </StyledButton>
                 </div>
 
                 <div class="secondary-actions">
-                    <StyledButton v-if="!isSessionActive" @click="this.$emit('show-add-identity')" text-color="#222"
-                        button-color="#fff">
+                    <StyledButton v-if="!isSessionActive" @click="this.$emit('show-add-identity')"
+                        text-color="#0b1430" button-color="#fdf3ff">
                         Create Identity
                     </StyledButton>
 
-                    <StyledButton v-if="!isSessionActive" @click="handleRefresh()" text-color="#ccc"
-                        button-color="#222">
+                    <StyledButton v-if="!isSessionActive" @click="handleRefresh()" text-color="#e2e7ff"
+                        button-color="rgba(23, 28, 55, 0.85)"
+                        :disabled-button-color="'rgba(23, 28, 55, 0.5)'">
                         Refresh Page
                     </StyledButton>
 
-                    <StyledButton @click="logOut()" text-color="#ccc" button-color="#222">
+                    <StyledButton @click="logOut()" text-color="#e2e7ff" button-color="rgba(23, 28, 55, 0.85)">
                         Log Out
                     </StyledButton>
                 </div>
@@ -131,13 +138,14 @@ export default {
     height: 100%;
     display: flex;
     flex-direction: column;
+    gap: 1.2rem;
 }
 
 .session-manager>div {
     display: grid;
-    grid-template-columns: 1fr 3fr;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 3fr);
     align-items: start;
-    gap: .7rem;
+    gap: 1.1rem;
 }
 
 .session-manager>div:last-child {
@@ -154,13 +162,24 @@ export default {
     display: flex;
     flex-direction: column;
     justify-content: space-between;
+    gap: 1.5rem;
 }
 
 .control-panel>div {
     width: 100%;
     display: flex;
     flex-direction: column;
-    gap: .7rem;
+    gap: .85rem;
+    background: linear-gradient(160deg, rgba(17, 24, 53, 0.9), rgba(10, 13, 30, 0.6));
+    border-radius: 1.25rem;
+    border: 1px solid rgba(120, 137, 255, 0.2);
+    padding: 1.1rem;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+    backdrop-filter: blur(16px);
+}
+
+.control-panel .secondary-actions {
+    background: linear-gradient(160deg, rgba(17, 24, 53, 0.85), rgba(13, 16, 34, 0.7));
 }
 
 .identity-pane {
@@ -173,11 +192,11 @@ export default {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding: 0 1rem .25rem 1rem;
-    font-weight: bold;
+    padding: 0 1rem .75rem 1rem;
+    font-weight: 600;
     text-transform: uppercase;
     font-size: .75rem;
-    letter-spacing: .05em;
-    color: #ccc;
+    letter-spacing: .08em;
+    color: rgba(218, 225, 255, 0.75);
 }
 </style>

--- a/src/components/StyledButton.vue
+++ b/src/components/StyledButton.vue
@@ -43,17 +43,24 @@ export default {
         ? this.disabledTextColor || this.adjustColor(this.textColor, 1)
         : this.textColor;
 
+      const background = backgroundColor;
+      const isGradient = typeof background === 'string' && background.includes('gradient');
+
       return {
         color,
-        backgroundColor,
-        border: 'none',
-        padding: '.5rem .7rem',
-        borderRadius: '.5rem',
+        background,
+        backgroundColor: isGradient ? 'transparent' : background,
+        border: isGradient ? '1px solid rgba(255, 255, 255, 0.08)' : 'none',
+        padding: '.65rem .9rem',
+        borderRadius: '.85rem',
         cursor: this.disabled ? 'not-allowed' : 'pointer',
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',
-        pointerEvents: this.disabled ? 'none' : 'auto'
+        pointerEvents: this.disabled ? 'none' : 'auto',
+        boxShadow: isGradient && !this.disabled ? '0 18px 40px rgba(108, 126, 255, 0.35)' : 'none',
+        transition: 'transform 0.3s ease, box-shadow 0.3s ease, background 0.3s ease, color 0.3s ease',
+        backdropFilter: isGradient ? 'blur(6px)' : 'none'
       };
     }
   },
@@ -99,17 +106,19 @@ export default {
 <style scoped>
 .styled-button {
   width: 100%;
-  transition: background-color 0.3s, color 0.3s;
-  font-size: .9rem;
+  transition: transform 0.3s ease, box-shadow 0.3s ease, filter 0.3s ease;
+  font-size: .95rem;
   font-weight: bold;
   text-transform: capitalize;
 }
 
 .styled-button:hover {
-  filter: brightness(0.9);
+  filter: brightness(1.02);
+  transform: translateY(-2px);
 }
 
 .styled-button:disabled {
   filter: none;
+  transform: none;
 }
 </style>


### PR DESCRIPTION
## Summary
- Replaced the top/bottom layout with a hero-driven dashboard that mirrors n8n's gradient aesthetic, including animated background elements and stat callouts
- Wrapped the identity search and session manager in glassmorphism panels with updated copy to guide users through building sessions
- Modernized shared styling, button treatments, and module-specific controls to support gradient buttons and refined dark-mode visuals

## Testing
- npm run build *(fails: `vue-cli-service` is unavailable in the current environment)*

------
https://chatgpt.com/codex/tasks/task_b_68dfde8b59d48328b803b5c237fcb851